### PR TITLE
fix transit logout function

### DIFF
--- a/packages/eos-transit/src/wallet.ts
+++ b/packages/eos-transit/src/wallet.ts
@@ -289,7 +289,7 @@ export function initWallet(walletProvider: WalletProvider, ctx: WalletAccessCont
 	}
 
 	function logout(): Promise<boolean> {
-		return walletProvider.disconnect().then(() => {
+		return walletProvider.logout().then(() => {
 			_stateContainer.updateState((state) => ({
 				...state,
 				accountInfo: void 0,


### PR DESCRIPTION
Logout function will now call correct wallet provider's logout function vs disconnect