### PR TITLE
Expose sign method to sign arbitrary signature

### DIFF
--- a/packages/eos-transit-ledger-provider/src/index.ts
+++ b/packages/eos-transit-ledger-provider/src/index.ts
@@ -243,7 +243,12 @@ export function ledgerWalletProvider(
 			discover,
 			disconnect,
 			login,
-			logout
+			logout,
+			sign: (publicKey: string, data: string): Promise<any> => {
+				return new Promise((resolve, reject) => {
+					reject("not implemented");
+				});
+			}
 		};
 
 		return walletProvider;

--- a/packages/eos-transit-scatter-provider/src/index.ts
+++ b/packages/eos-transit-scatter-provider/src/index.ts
@@ -83,6 +83,10 @@ export function scatterWalletProvider() {
 			return scatter.forgetIdentity();
 		}
 
+		function sign(publicKey: string, data:string): Promise<any> {
+			return scatter.getArbitrarySignature(publicKey, data)
+		}
+
 		const walletProvider: WalletProvider = {
 			id: 'scatter',
 			meta: {

--- a/packages/eos-transit-scatter-provider/src/index.ts
+++ b/packages/eos-transit-scatter-provider/src/index.ts
@@ -99,7 +99,8 @@ export function scatterWalletProvider() {
 			discover,
 			disconnect,
 			login,
-			logout
+			logout,
+			sign
 		};
 
 		return walletProvider;

--- a/packages/eos-transit-stub-provider/src/index.ts
+++ b/packages/eos-transit-stub-provider/src/index.ts
@@ -79,7 +79,12 @@ export function stubWalletProvider({
       connect,
       disconnect,
       login,
-      logout
+      logout,
+      sign: (publicKey: string, data: string): Promise<any> => {
+				return new Promise((resolve, reject) => {
+					reject("not implemented");
+				});
+			}
     };
 
     return walletProvider;

--- a/packages/eos-transit/src/types.ts
+++ b/packages/eos-transit/src/types.ts
@@ -88,6 +88,8 @@ export interface WalletProvider {
 	disconnect(): Promise<any>;
 	login(accountName?: string, authorization?: string, index?: number, key?: string): Promise<WalletAuth>;
 	logout(accountName?: string): Promise<any>;
+	sign(publicKey: string, data: string): Promise<any>;
+
 }
 
 export type MakeWalletProviderFn = (network: NetworkConfig) => WalletProvider;

--- a/packages/eos-transit/src/types.ts
+++ b/packages/eos-transit/src/types.ts
@@ -89,7 +89,6 @@ export interface WalletProvider {
 	login(accountName?: string, authorization?: string, index?: number, key?: string): Promise<WalletAuth>;
 	logout(accountName?: string): Promise<any>;
 	sign(publicKey: string, data: string): Promise<any>;
-
 }
 
 export type MakeWalletProviderFn = (network: NetworkConfig) => WalletProvider;

--- a/packages/eos-transit/src/wallet.ts
+++ b/packages/eos-transit/src/wallet.ts
@@ -303,6 +303,10 @@ export function initWallet(walletProvider: WalletProvider, ctx: WalletAccessCont
 		});
 	}
 
+	function sign(publicKey: string, data: string): Promise<any> {
+		return walletProvider.sign(publicKey, data);
+	}
+	
 	const wallet: Wallet = {
 		_instanceId,
 		ctx,


### PR DESCRIPTION
Expose sign method in wallet provider object to sign the arbitrary signature for account ownership proof.